### PR TITLE
Use variable kubernetes_certs_dir where possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ requires loadbalancer or keepalived for HA; recommended role for keepalived inst
 | kubernetes_apiserver_dns | false | "" | dns-name for kubernetes apiserver |
 | kubernetes_apiserver_port | false | "6443" | port of kubernetes apiserver |
 | kubernetes_imageRepository | false | "k8s.gcr.io" | docker registry for kubernetes master components |
-| kubernetes_certs_dir | false | "/etc/kubernetes/pki" | certs folder |
+| kubernetes_config_dir | false | "/etc/kubernetes" | Config path |
+| kubernetes_certs_dir | false | "{{ kubernetes_config_dir }}/pki" | certs folder |
 | kubernetes_log_dir | false | | "/var/log/kubernetes/audit" | log folder |
 | kubernetes_log_age | false | 2 | max age of logfiles |
 | kubernetes_etcd_data_dir | false | "/var/etcd" | folder for etcd data |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,7 +22,8 @@ kubernetes_apiserver_dns: ""
 kubernetes_apiserver_port: "6443"
 kubernetes_imageRepository: "k8s.gcr.io"
 kubernetes_master_version: "v1.12.0"
-kubernetes_certs_dir: "/etc/kubernetes/pki"
+kubernetes_config_dir: /etc/kubernetes
+kubernetes_certs_dir: "{{ kubernetes_config_dir }}/pki"
 kubernetes_cluster_name: "kubernetes"
 kubernetes_log_dir: "/var/log/kubernetes/audit"
 kubernetes_log_age: 2

--- a/tasks/etcd.yml
+++ b/tasks/etcd.yml
@@ -3,16 +3,16 @@
 - name: ensure folder pki/etcd exists
   file:
     state: directory
-    path: /etc/kubernetes/pki/etcd
+    path: '{{ kubernetes_certs_dir }}/etcd'
 
-- name: check /etc/kubernetes/pki/etcd/ca.crt / ca.key exists
+- name: 'check {{ kubernetes_certs_dir }}/etcd/ca.crt / ca.key exists'
   stat:
     path: "{{ item }}"
   register: etcd_ca_result
   when: "inventory_hostname == groups.etcd[0]"
   with_items:
-    - /etc/kubernetes/pki/etcd/ca.crt
-    - /etc/kubernetes/pki/etcd/ca.key
+    - '{{ kubernetes_certs_dir }}/etcd/ca.crt'
+    - '{{ kubernetes_certs_dir }}/etcd/ca.key'
 
 - name: generate etcd-ca cert
   command: kubeadm alpha phase certs etcd-ca --config=/etc/kubernetes/kubeadm/clusterconfig.yaml
@@ -25,8 +25,8 @@
   slurp:
     src: "{{ item }}"
   with_items:
-    - /etc/kubernetes/pki/etcd/ca.crt
-    - /etc/kubernetes/pki/etcd/ca.key
+    - '{{ kubernetes_certs_dir }}/etcd/ca.crt'
+    - '{{ kubernetes_certs_dir }}/etcd/ca.key'
   register: etcd_ca_certs_register
   run_once: true
 
@@ -36,49 +36,49 @@
     dest: "{{ item.source }}"
   with_items: "{{ etcd_ca_certs_register.results }}"
 
-- name: check /etc/kubernetes/pki/etcd/server.crt/.key exists
+- name: 'check {{ kubernetes_certs_dir }}/etcd/server.crt/.key exists'
   stat:
     path: "{{ item }}"
   register: etcd_server_result
   with_items:
-    - /etc/kubernetes/pki/etcd/server.crt
-    - /etc/kubernetes/pki/etcd/server.key
+    - '{{ kubernetes_certs_dir }}/etcd/server.crt'
+    - '{{ kubernetes_certs_dir }}/etcd/server.key'
 
 - name: generate etcd-server cert
   command: kubeadm alpha phase certs etcd-server --config=/etc/kubernetes/kubeadm/clusterconfig.yaml
   when: "etcd_server_result.results[0].stat.exists == False and etcd_server_result.results[1].stat.exists == False"
 
-- name: check /etc/kubernetes/pki/etcd/peer.crt/.key exists
+- name: 'check {{ kubernetes_certs_dir }}/etcd/peer.crt/.key exists'
   stat:
     path: "{{ item }}"
   register: etcd_peer_result
   with_items:
-    - /etc/kubernetes/pki/etcd/peer.crt
-    - /etc/kubernetes/pki/etcd/peer.key
+    - '{{ kubernetes_certs_dir }}/etcd/peer.crt'
+    - '{{ kubernetes_certs_dir }}/etcd/peer.key'
 
 - name: generate etcd-peer cert
   command: kubeadm alpha phase certs etcd-peer --config=/etc/kubernetes/kubeadm/clusterconfig.yaml
   when: "etcd_peer_result.results[0].stat.exists == False and etcd_peer_result.results[1].stat.exists == False"
 
-- name: check /etc/kubernetes/pki/etcd/healthcheck-client.crt/.key exists
+- name: 'check {{ kubernetes_certs_dir }}/etcd/healthcheck-client.crt/.key exists'
   stat:
     path: "{{ item }}"
   register: etcd_health_result
   with_items:
-    - /etc/kubernetes/pki/etcd/healthcheck-client.crt
-    - /etc/kubernetes/pki/etcd/healthcheck-client.key
+    - '{{ kubernetes_certs_dir }}/etcd/healthcheck-client.crt'
+    - '{{ kubernetes_certs_dir }}/etcd/healthcheck-client.key'
 
 - name: generate etcd-healthcheck-client cert
   command: kubeadm alpha phase certs etcd-healthcheck-client --config=/etc/kubernetes/kubeadm/clusterconfig.yaml
   when: "etcd_health_result.results[0].stat.exists == False and etcd_health_result.results[1].stat.exists == False"
 
-- name: check /etc/kubernetes/pki/apiserver-etcd-client.crt/.key exists
+- name: 'check {{ kubernetes_certs_dir }}/apiserver-etcd-client.crt/.key exists'
   stat:
     path: "{{ item }}"
   register: etcd_apiclient_result
   with_items:
-    - /etc/kubernetes/pki/apiserver-etcd-client.crt
-    - /etc/kubernetes/pki/apiserver-etcd-client.key
+    - '{{ kubernetes_certs_dir }}/apiserver-etcd-client.crt'
+    - '{{ kubernetes_certs_dir }}/apiserver-etcd-client.key'
 
 - name: generate etcd-apiserver-etcd-client cert
   command: kubeadm alpha phase certs apiserver-etcd-client --config=/etc/kubernetes/kubeadm/clusterconfig.yaml
@@ -127,5 +127,5 @@
     detach: no
     volumes:
       - /etc/kubernetes:/etc/kubernetes
-    command: "etcdctl --cert-file /etc/kubernetes/pki/etcd/peer.crt --key-file /etc/kubernetes/pki/etcd/peer.key --ca-file /etc/kubernetes/pki/etcd/ca.crt --endpoints https://{{ ansible_ssh_host }}:2379 cluster-health"
+    command: "etcdctl --cert-file /etc/kubernetes/pki/etcd/peer.crt --key-file /etc/kubernetes/pki/etcd/peer.key --ca-file {{ kubernetes_certs_dir }}/etcd/ca.crt --endpoints https://{{ ansible_ssh_host }}:2379 cluster-health"
   changed_when: False

--- a/tasks/master-ha.yml
+++ b/tasks/master-ha.yml
@@ -5,12 +5,12 @@
   slurp:
     src: "{{ item }}"
   with_items:
-    - /etc/kubernetes/pki/ca.crt
-    - /etc/kubernetes/pki/ca.key
-    - /etc/kubernetes/pki/sa.key
-    - /etc/kubernetes/pki/sa.pub
-    - /etc/kubernetes/pki/front-proxy-ca.crt
-    - /etc/kubernetes/pki/front-proxy-ca.key
+    - '{{ kubernetes_certs_dir }}/ca.crt'
+    - '{{ kubernetes_certs_dir }}/ca.key'
+    - '{{ kubernetes_certs_dir }}/sa.key'
+    - '{{ kubernetes_certs_dir }}/sa.pub'
+    - '{{ kubernetes_certs_dir }}/front-proxy-ca.crt'
+    - '{{ kubernetes_certs_dir }}/front-proxy-ca.key'
     - /etc/kubernetes/admin.conf
   register: master_certs_configs_register
 
@@ -25,12 +25,12 @@
     path: "{{ item }}"
   register: master_certs_result
   with_items:
-    - /etc/kubernetes/pki/apiserver-kubelet-client.crt
-    - /etc/kubernetes/pki/apiserver-kubelet-client.key
-    - /etc/kubernetes/pki/apiserver.crt
-    - /etc/kubernetes/pki/apiserver.key
-    - /etc/kubernetes/pki/front-proxy-client.crt
-    - /etc/kubernetes/pki/front-proxy-client.key
+    - '{{ kubernetes_certs_dir }}/apiserver-kubelet-client.crt'
+    - '{{ kubernetes_certs_dir }}/apiserver-kubelet-client.key'
+    - '{{ kubernetes_certs_dir }}/apiserver.crt'
+    - '{{ kubernetes_certs_dir }}/apiserver.key'
+    - '{{ kubernetes_certs_dir }}/front-proxy-client.crt'
+    - '{{ kubernetes_certs_dir }}/front-proxy-client.key'
 
 - name: gen certs on master ha nodes
   command: kubeadm alpha phase certs all --config /etc/kubernetes/kubeadm/clusterconfig.yaml

--- a/tasks/master.yml
+++ b/tasks/master.yml
@@ -3,15 +3,15 @@
 - name: ensure folder pki/etcd exists
   file:
     state: directory
-    path: /etc/kubernetes/pki/etcd
+    path: '{{ kubernetes_certs_dir }}/etcd'
 
 - name: get apiserver-etcd-client.crt files from first etcd node
   delegate_to: "{{ groups.etcd[0] }}"
   slurp:
     src: "{{ item }}"
   with_items:
-    - /etc/kubernetes/pki/apiserver-etcd-client.crt
-    - /etc/kubernetes/pki/apiserver-etcd-client.key
+    - '{{ kubernetes_certs_dir }}/apiserver-etcd-client.crt'
+    - '{{ kubernetes_certs_dir }}/apiserver-etcd-client.key'
   register: etcd_apiserver_certs_register
 
 - name: copy etcd cert files to master nodes


### PR DESCRIPTION
This patches makes use of the already defined variable __kubernetes_certs_dir__ where possible.