### PR TITLE
replaced ansible_ssh_host by ansible_host

### DIFF
--- a/tests/master_ha/inventory
+++ b/tests/master_ha/inventory
@@ -7,14 +7,14 @@ k8s_nodes
 docker_version="18.06.0"
 
 [etcd]
-k8s-master-01 ansible_ssh_host=192.168.10.121 ansible_user=vagrant
-k8s-master-02 ansible_ssh_host=192.168.10.122 ansible_user=vagrant
-k8s-master-03 ansible_ssh_host=192.168.10.123 ansible_user=vagrant
+k8s-master-01 ansible_host=192.168.10.121 ansible_user=vagrant
+k8s-master-02 ansible_host=192.168.10.122 ansible_user=vagrant
+k8s-master-03 ansible_host=192.168.10.123 ansible_user=vagrant
 
 [k8s_masters]
-k8s-master-01 ansible_ssh_host=192.168.10.121 ansible_user=vagrant
-k8s-master-02 ansible_ssh_host=192.168.10.122 ansible_user=vagrant
-k8s-master-03 ansible_ssh_host=192.168.10.123 ansible_user=vagrant
+k8s-master-01 ansible_host=192.168.10.121 ansible_user=vagrant
+k8s-master-02 ansible_host=192.168.10.122 ansible_user=vagrant
+k8s-master-03 ansible_host=192.168.10.123 ansible_user=vagrant
 
 [k8s_nodes]
-k8s-worker-01 ansible_ssh_host=192.168.10.130 ansible_user=vagrant
+k8s-worker-01 ansible_host=192.168.10.130 ansible_user=vagrant


### PR DESCRIPTION
In the code when generating the kubeconfig you reference ansible_host. The usage of ansible_ssh_host is deprecated. So we should use the correct version in your example as well.